### PR TITLE
Add ruler as a store for thanos-querier

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -190,6 +190,7 @@ services:
             - '--store=thanos-sidecar-3:10091'
             - '--store=thanos-sidecar-4:10091'
             - '--store=thanos-store-gateway:10091'
+            - '--store=thanos-ruler:10091'
         ports:
             - 10902:10902
         depends_on:


### PR DESCRIPTION
For Thanos Query to pickup recording rules we need to add it as a store in thanos-querier configuration, see 
![image](https://user-images.githubusercontent.com/64898324/136032743-0f8f95b0-1c75-46d2-892e-26660a87f11e.png)

https://thanos.io/tip/components/rule.md/#recording-rules
